### PR TITLE
Implement recursive brace expansion

### DIFF
--- a/include/hit/braceexpr.h
+++ b/include/hit/braceexpr.h
@@ -6,7 +6,9 @@
 #include <vector>
 #include <list>
 #include <map>
+#include <memory>
 #include <sstream>
+#include <variant>
 
 namespace hit
 {
@@ -68,34 +70,102 @@ private:
 };
 
 size_t parseBraceNode(const std::string & input, size_t start, BraceNode & n);
+
+class BraceExpr;
+using BracePart = std::variant<std::string, std::shared_ptr<BraceExpr>>;
+
+class BraceTemplate
+{
+public:
+  inline std::vector<BracePart> & parts() { return _parts; }
+  inline const std::vector<BracePart> & parts() const { return _parts; }
+  bool pureExpression() const;
+  bool hasLiteralText() const;
+  std::size_t expressionCount() const;
+
+private:
+  std::vector<BracePart> _parts;
+};
+
+class BraceArg
+{
+public:
+  inline BraceTemplate & value() { return _value; }
+  inline const BraceTemplate & value() const { return _value; }
+
+private:
+  BraceTemplate _value;
+};
+
+class BraceExpr
+{
+public:
+  inline std::vector<BraceArg> & args() { return _args; }
+  inline const std::vector<BraceArg> & args() const { return _args; }
+  inline std::size_t & line() { return _line; }
+  inline const std::size_t & line() const { return _line; }
+  inline std::size_t & column() { return _column; }
+  inline const std::size_t & column() const { return _column; }
+  inline std::size_t & position() { return _position; }
+  inline const std::size_t & position() const { return _position; }
+  inline std::size_t & length() { return _length; }
+  inline const std::size_t & length() const { return _length; }
+  inline std::string & text() { return _text; }
+  inline const std::string & text() const { return _text; }
+
+private:
+  std::vector<BraceArg> _args;
+  std::size_t _line = 1;
+  std::size_t _column = 1;
+  std::size_t _position = 0;
+  std::size_t _length = 0;
+  std::string _text;
+};
+
+struct BraceParseError
+{
+  std::size_t line = 1;
+  std::size_t column = 1;
+  std::string message;
+};
+
+BraceTemplate parseBraceTemplate(const std::string & input, BraceParseError * error = nullptr);
 class BraceExpander;
+
+struct EvalResult
+{
+  std::string value;
+  Field::Kind kind = Field::Kind::None;
+  std::vector<std::string> used;
+};
 
 class Evaler
 {
 public:
   virtual ~Evaler() {}
-  virtual std::string eval(Field * n, const std::list<std::string> & args, BraceExpander & exp) = 0;
+  virtual EvalResult
+  eval(Field * n, const std::vector<std::string> & args, BraceExpander & exp) = 0;
 };
 
 class EnvEvaler : public Evaler
 {
 public:
-  virtual std::string
-  eval(Field * n, const std::list<std::string> & args, BraceExpander & exp) override;
+  virtual EvalResult
+  eval(Field * n, const std::vector<std::string> & args, BraceExpander & exp) override;
 };
 
 class RawEvaler : public Evaler
 {
 public:
-  virtual std::string
-  eval(Field * n, const std::list<std::string> & args, BraceExpander & exp) override;
+  virtual EvalResult
+  eval(Field * n, const std::vector<std::string> & args, BraceExpander & exp) override;
 };
 
 class ReplaceEvaler : public Evaler
 {
 public:
-  virtual std::string
-  eval(Field * n, const std::list<std::string> & args, BraceExpander & exp) override;
+  virtual EvalResult
+  eval(Field * n, const std::vector<std::string> & args, BraceExpander & exp) override;
 };
 
 class BraceExpander : public Walker
@@ -105,13 +175,39 @@ public:
   void registerEvaler(const std::string & name, Evaler & ev);
   virtual void walk(const std::string & /*fullpath*/, const std::string & /*nodepath*/, Node * n);
   std::string expand(Field * n, const std::string & input);
+  Field *
+  findReferencedField(Field * n, const std::string & path, std::string * used_path = nullptr);
+  const EvalResult & resolve(Field * n);
+  ErrorMessage currentExpressionErrorMessage(Field * n, const std::string & message) const;
+  Error currentExpressionError(Field * n, const std::string & message) const;
 
   std::vector<std::string> used;
   std::vector<ErrorMessage> errors;
 
 private:
-  std::string expand(Field * n, BraceNode & expr);
+  enum class ResolveState
+  {
+    Unvisited,
+    Resolving,
+    Resolved
+  };
+
+  struct ResolveEntry
+  {
+    ResolveState state = ResolveState::Unvisited;
+    EvalResult result;
+  };
+
+  EvalResult evaluate(Field * n, const BraceTemplate & expr);
+  EvalResult evaluate(Field * n, const BraceExpr & expr);
+  Error syntaxError(Field * n, const BraceParseError & error) const;
+  Error expressionError(Field * n, const BraceExpr & expr, const std::string & message) const;
+  ErrorMessage
+  expressionErrorMessage(Field * n, const BraceExpr & expr, const std::string & message) const;
   std::map<std::string, Evaler *> _evalers;
+  std::map<Field *, ResolveEntry> _resolved;
+  std::vector<Field *> _resolving_stack;
+  const BraceExpr * _active_expr = nullptr;
   ReplaceEvaler _replace;
 };
 

--- a/include/hit/braceexpr.h
+++ b/include/hit/braceexpr.h
@@ -54,95 +54,177 @@ errormsg(Node * n, T arg, Args... args)
 class BraceNode
 {
 public:
+  /// Render this node and its children as an indented debug string.
   std::string str(int indent = 0);
+
+  /// Append a new child node and return it for in-place population during parsing.
   BraceNode & append();
 
+  /// Access the nested brace nodes collected beneath this node.
   inline std::vector<BraceNode> & list() { return _list; }
+
+  /// Access the literal text stored for this node between nested brace expressions.
   inline std::string & val() { return _val; }
+
+  /// Access the byte offset of this node within the original brace expression.
   inline size_t & offset() { return _offset; }
+
+  /// Access the span length covered by this node in the original input.
   inline size_t & len() { return _len; }
 
 private:
+  /// Byte offset where this parsed node begins in the source expression.
   size_t _offset;
+
+  /// Number of characters covered by this node in the source expression.
   size_t _len;
+
+  /// Literal text content associated with this node.
   std::string _val;
+
+  /// Child nodes representing nested brace expressions.
   std::vector<BraceNode> _list;
 };
 
+/// Parse a brace node beginning at \p start and store the resulting subtree in \p n.
 size_t parseBraceNode(const std::string & input, size_t start, BraceNode & n);
 
 class BraceExpr;
+
+/// One segment of a parsed template, either literal text or a nested brace expression.
 using BracePart = std::variant<std::string, std::shared_ptr<BraceExpr>>;
 
 class BraceTemplate
 {
 public:
+  /// Access the ordered sequence of literal and nested-expression parts in this template.
   inline std::vector<BracePart> & parts() { return _parts; }
+
+  /// Access the ordered sequence of literal and nested-expression parts in this template.
   inline const std::vector<BracePart> & parts() const { return _parts; }
+
+  /// Determine whether this template consists of a single brace expression and no literal text.
   bool pureExpression() const;
+
+  /// Determine whether any literal text remains alongside embedded expressions.
   bool hasLiteralText() const;
+
+  /// Count the number of embedded brace expressions stored in this template.
   std::size_t expressionCount() const;
 
 private:
+  /// Template fragments preserved in source order for later evaluation.
   std::vector<BracePart> _parts;
 };
 
 class BraceArg
 {
 public:
+  /// Access the parsed template that supplies this argument's value.
   inline BraceTemplate & value() { return _value; }
+
+  /// Access the parsed template that supplies this argument's value.
   inline const BraceTemplate & value() const { return _value; }
 
 private:
+  /// Argument payload, which may itself contain nested brace expressions.
   BraceTemplate _value;
 };
 
 class BraceExpr
 {
 public:
+  /// Access the argument list parsed from the current brace expression.
   inline std::vector<BraceArg> & args() { return _args; }
+
+  /// Access the argument list parsed from the current brace expression.
   inline const std::vector<BraceArg> & args() const { return _args; }
+
+  /// Access the 1-based source line where this expression begins.
   inline std::size_t & line() { return _line; }
+
+  /// Access the 1-based source line where this expression begins.
   inline const std::size_t & line() const { return _line; }
+
+  /// Access the 1-based source column where this expression begins.
   inline std::size_t & column() { return _column; }
+
+  /// Access the 1-based source column where this expression begins.
   inline const std::size_t & column() const { return _column; }
+
+  /// Access the byte position of this expression within the original field value.
   inline std::size_t & position() { return _position; }
+
+  /// Access the byte position of this expression within the original field value.
   inline const std::size_t & position() const { return _position; }
+
+  /// Access the number of characters occupied by this expression in the source text.
   inline std::size_t & length() { return _length; }
+
+  /// Access the number of characters occupied by this expression in the source text.
   inline const std::size_t & length() const { return _length; }
+
+  /// Access the original expression text, including braces, for diagnostics.
   inline std::string & text() { return _text; }
+
+  /// Access the original expression text, including braces, for diagnostics.
   inline const std::string & text() const { return _text; }
 
 private:
+  /// Parsed arguments passed to the evaluator named by the first argument.
   std::vector<BraceArg> _args;
+
+  /// 1-based line number where this expression starts in the source field.
   std::size_t _line = 1;
+
+  /// 1-based column number where this expression starts in the source field.
   std::size_t _column = 1;
+
+  /// Byte offset of the opening brace relative to the source field value.
   std::size_t _position = 0;
+
+  /// Number of characters spanning the full brace expression.
   std::size_t _length = 0;
+
+  /// Original source text for this expression, preserved for error reporting.
   std::string _text;
 };
 
 struct BraceParseError
 {
+  /// 1-based source line where parsing failed.
   std::size_t line = 1;
+
+  /// 1-based source column where parsing failed.
   std::size_t column = 1;
+
+  /// Human-readable description of the parse failure.
   std::string message;
 };
 
+/// Parse an input string into a brace-expression template with nested-expression structure preserved.
 BraceTemplate parseBraceTemplate(const std::string & input, BraceParseError * error = nullptr);
 class BraceExpander;
 
 struct EvalResult
 {
+  /// Final text produced by evaluating the requested brace expression.
   std::string value;
+
+  /// Field kind associated with the resolved value, when one is available.
   Field::Kind kind = Field::Kind::None;
+
+  /// Fully qualified field paths consumed while producing this result.
   std::vector<std::string> used;
 };
 
 class Evaler
 {
 public:
+  /// Virtual destructor for evaluator implementations used through the base interface.
   virtual ~Evaler() {}
+
+  /// Evaluate a brace expression invocation against field \p n with already-expanded \p args.
   virtual EvalResult
   eval(Field * n, const std::vector<std::string> & args, BraceExpander & exp) = 0;
 };
@@ -150,6 +232,7 @@ public:
 class EnvEvaler : public Evaler
 {
 public:
+  /// Resolve an environment-variable substitution request.
   virtual EvalResult
   eval(Field * n, const std::vector<std::string> & args, BraceExpander & exp) override;
 };
@@ -157,6 +240,7 @@ public:
 class RawEvaler : public Evaler
 {
 public:
+  /// Return the unexpanded value of a referenced field.
   virtual EvalResult
   eval(Field * n, const std::vector<std::string> & args, BraceExpander & exp) override;
 };
@@ -164,6 +248,7 @@ public:
 class ReplaceEvaler : public Evaler
 {
 public:
+  /// Perform string replacement on the evaluated input arguments.
   virtual EvalResult
   eval(Field * n, const std::vector<std::string> & args, BraceExpander & exp) override;
 };
@@ -171,43 +256,83 @@ public:
 class BraceExpander : public Walker
 {
 public:
+  /// Construct an expander with the built-in replacement evaluator available.
   BraceExpander() {}
+
+  /// Register an evaluator implementation under the function name used in brace expressions.
   void registerEvaler(const std::string & name, Evaler & ev);
+
+  /// Expand brace expressions for each visited field while traversing a HIT tree.
   virtual void walk(const std::string & /*fullpath*/, const std::string & /*nodepath*/, Node * n);
+
+  /// Expand all brace expressions found in \p input relative to field \p n.
   std::string expand(Field * n, const std::string & input);
+
+  /// Locate the field referenced by \p path relative to \p n and optionally record the normalized path.
   Field *
   findReferencedField(Field * n, const std::string & path, std::string * used_path = nullptr);
+
+  /// Resolve a field once, caching the result and detecting dependency cycles.
   const EvalResult & resolve(Field * n);
+
+  /// Build an error message against the currently active expression span.
   ErrorMessage currentExpressionErrorMessage(Field * n, const std::string & message) const;
+
+  /// Build an error object against the currently active expression span.
   Error currentExpressionError(Field * n, const std::string & message) const;
 
+  /// Field paths referenced while expanding the current input.
   std::vector<std::string> used;
+
+  /// Errors collected during tree traversal and expression evaluation.
   std::vector<ErrorMessage> errors;
 
 private:
   enum class ResolveState
   {
-    Unvisited,
-    Resolving,
-    Resolved
+    Unvisited, /// Field has not yet been evaluated during this expansion pass.
+    Resolving, /// Field evaluation is in progress and should trigger cycle detection if revisited.
+    Resolved   /// Field evaluation completed and the cached result is valid.
   };
 
   struct ResolveEntry
   {
+    /// Current resolution state used to detect recursion through brace dependencies.
     ResolveState state = ResolveState::Unvisited;
+
+    /// Cached expansion result for the corresponding field.
     EvalResult result;
   };
 
+  /// Evaluate a parsed template by concatenating its literal and expression parts.
   EvalResult evaluate(Field * n, const BraceTemplate & expr);
+
+  /// Evaluate a single brace expression invocation.
   EvalResult evaluate(Field * n, const BraceExpr & expr);
+
+  /// Convert a parse failure into a HIT error associated with field \p n.
   Error syntaxError(Field * n, const BraceParseError & error) const;
+
+  /// Build an error object covering the source span of a parsed brace expression.
   Error expressionError(Field * n, const BraceExpr & expr, const std::string & message) const;
+
+  /// Build an error message covering the source span of a parsed brace expression.
   ErrorMessage
   expressionErrorMessage(Field * n, const BraceExpr & expr, const std::string & message) const;
+
+  /// Registered evaluator implementations keyed by brace-expression function name.
   std::map<std::string, Evaler *> _evalers;
+
+  /// Per-field cached results and recursion state for dependency-aware resolution.
   std::map<Field *, ResolveEntry> _resolved;
+
+  /// Stack of fields currently being resolved to report dependency cycles clearly.
   std::vector<Field *> _resolving_stack;
+
+  /// Expression currently being evaluated, used to anchor contextual diagnostics.
   const BraceExpr * _active_expr = nullptr;
+
+  /// Built-in evaluator that backs `${replace ...}` expressions.
   ReplaceEvaler _replace;
 };
 

--- a/src/hit/braceexpr.cc
+++ b/src/hit/braceexpr.cc
@@ -6,6 +6,229 @@
 namespace hit
 {
 
+namespace
+{
+
+class BraceTemplateParser
+{
+public:
+  BraceTemplateParser(const std::string & input, BraceParseError * error)
+    : _input(input), _error(error)
+  {
+  }
+
+  BraceTemplate parse()
+  {
+    auto result = parseTemplate(ParseMode::TopLevel);
+    if (!eof())
+      failHere("unexpected trailing input");
+    return result;
+  }
+
+private:
+  enum class ParseMode
+  {
+    TopLevel,
+    Argument
+  };
+
+  struct Position
+  {
+    std::size_t index;
+    std::size_t line;
+    std::size_t column;
+  };
+
+  bool eof() const { return _pos >= _input.size(); }
+
+  char current() const { return eof() ? '\0' : _input[_pos]; }
+
+  bool startsExpr() const { return _input.compare(_pos, 2, "${") == 0; }
+
+  static bool isWhitespace(char c)
+  {
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+  }
+
+  Position mark() const { return {_pos, _line, _column}; }
+
+  void advance()
+  {
+    if (eof())
+      return;
+
+    if (_input[_pos] == '\n')
+    {
+      ++_line;
+      _column = 1;
+    }
+    else
+      ++_column;
+
+    ++_pos;
+  }
+
+  void advance(std::size_t count)
+  {
+    for (std::size_t i = 0; i < count; ++i)
+      advance();
+  }
+
+  void skipWhitespace()
+  {
+    while (!eof() && isWhitespace(current()))
+      advance();
+  }
+
+  [[noreturn]] void fail(const Position & pos, const std::string & message) const
+  {
+    if (_error && _error->message.empty())
+    {
+      _error->line = pos.line;
+      _error->column = pos.column;
+      _error->message = message;
+    }
+    throw Error("invalid brace expression");
+  }
+
+  [[noreturn]] void failHere(const std::string & message) const { fail(mark(), message); }
+
+  std::string slice(const Position & begin, const Position & end) const
+  {
+    return _input.substr(begin.index, end.index - begin.index);
+  }
+
+  BraceTemplate parseTemplate(ParseMode mode)
+  {
+    BraceTemplate root;
+    while (!eof())
+    {
+      if (startsExpr())
+        root.parts().push_back(parseExpression());
+      else if (mode == ParseMode::Argument && (current() == '}' || isWhitespace(current())))
+        break;
+      else
+      {
+        const auto start = mark();
+        while (!eof() && !startsExpr() &&
+               !(mode == ParseMode::Argument && (current() == '}' || isWhitespace(current()))))
+          advance();
+        root.parts().push_back(slice(start, mark()));
+      }
+    }
+
+    return root;
+  }
+
+  std::shared_ptr<BraceExpr> parseExpression()
+  {
+    if (!startsExpr())
+      failHere("missing opening '${' in brace expression");
+
+    const auto start = mark();
+    auto expr = std::make_shared<BraceExpr>();
+
+    advance(2);
+    skipWhitespace();
+
+    if (eof())
+      failHere("missing closing '}' in brace expression");
+
+    while (!eof() && current() != '}')
+    {
+      expr->args().push_back(parseArgument());
+      skipWhitespace();
+    }
+
+    if (eof() || current() != '}')
+      failHere("missing closing '}' in brace expression");
+
+    advance();
+
+    const auto end = mark();
+    expr->line() = start.line;
+    expr->column() = start.column;
+    expr->position() = start.index;
+    expr->length() = end.index - start.index;
+    expr->text() = slice(start, end);
+    return expr;
+  }
+
+  BraceArg parseArgument()
+  {
+    BraceArg arg;
+    auto & parts = arg.value().parts();
+
+    while (!eof() && current() != '}' && !isWhitespace(current()))
+      if (startsExpr())
+        parts.push_back(parseExpression());
+      else
+      {
+        const auto start = mark();
+        while (!eof() && !startsExpr() && current() != '}' && !isWhitespace(current()))
+          advance();
+        parts.push_back(slice(start, mark()));
+      }
+
+    if (parts.empty())
+      failHere("expected brace-expression argument");
+
+    return arg;
+  }
+
+  const std::string & _input;
+  BraceParseError * _error = nullptr;
+  std::size_t _pos = 0;
+  std::size_t _line = 1;
+  std::size_t _column = 1;
+};
+
+std::pair<int, int>
+fieldValueStart(const Field * n)
+{
+  int column = n->column() + static_cast<int>(n->path().size()) + 3;
+  if (quoteChar(n->val()) != "")
+    ++column;
+  return {n->line(), column};
+}
+
+std::pair<int, int>
+advanceLocation(int line, int column, const std::string & text)
+{
+  if (text.empty())
+    return {line, column};
+
+  for (std::size_t i = 1; i < text.size(); ++i)
+    if (text[i] == '\n')
+    {
+      ++line;
+      column = 1;
+    }
+    else
+      ++column;
+
+  return {line, column};
+}
+
+ErrorMessage
+fieldValueErrorMessage(Field * n,
+                       std::size_t rel_line,
+                       std::size_t rel_column,
+                       const std::string & span_text,
+                       const std::string & message)
+{
+  const auto [base_line, base_column] = fieldValueStart(n);
+
+  int start_line = base_line + static_cast<int>(rel_line) - 1;
+  int start_column =
+      rel_line == 1 ? base_column + static_cast<int>(rel_column) - 1 : static_cast<int>(rel_column);
+
+  const auto [end_line, end_column] = advanceLocation(start_line, start_column, span_text);
+  return ErrorMessage(message, n->filename(), start_line, start_column, end_line, end_column);
+}
+
+} // namespace
+
 std::string
 BraceNode::str(int indent)
 {
@@ -32,49 +255,81 @@ BraceNode::append()
   return _list.back();
 }
 
-std::string
-EnvEvaler::eval(Field * /*n*/, const std::list<std::string> & args, BraceExpander & /*exp*/)
+bool
+BraceTemplate::pureExpression() const
 {
+  return _parts.size() == 1 && std::holds_alternative<std::shared_ptr<BraceExpr>>(_parts.front());
+}
+
+bool
+BraceTemplate::hasLiteralText() const
+{
+  for (const auto & part : _parts)
+    if (std::holds_alternative<std::string>(part) && !std::get<std::string>(part).empty())
+      return true;
+
+  return false;
+}
+
+std::size_t
+BraceTemplate::expressionCount() const
+{
+  std::size_t count = 0;
+  for (const auto & part : _parts)
+    if (std::holds_alternative<std::shared_ptr<BraceExpr>>(part))
+      ++count;
+
+  return count;
+}
+
+BraceTemplate
+parseBraceTemplate(const std::string & input, BraceParseError * error)
+{
+  return BraceTemplateParser(input, error).parse();
+}
+
+EvalResult
+EnvEvaler::eval(Field * /*n*/, const std::vector<std::string> & args, BraceExpander & /*exp*/)
+{
+  EvalResult result;
+  result.kind = Field::Kind::String;
   std::string var = args.front();
-  std::string val;
   auto data = std::getenv(var.c_str());
   if (data)
-    val = data;
-  return val;
+    result.value = data;
+  return result;
 }
 
-std::string
-RawEvaler::eval(Field * /*n*/, const std::list<std::string> & args, BraceExpander & /*exp*/)
+EvalResult
+RawEvaler::eval(Field * /*n*/, const std::vector<std::string> & args, BraceExpander & /*exp*/)
 {
-  std::string s;
+  EvalResult result;
+  result.kind = Field::Kind::String;
   for (auto & arg : args)
-    s += arg;
-  return s;
+    result.value += arg;
+  return result;
 }
 
-std::string
-ReplaceEvaler::eval(Field * n, const std::list<std::string> & args, BraceExpander & exp)
+EvalResult
+ReplaceEvaler::eval(Field * n, const std::vector<std::string> & args, BraceExpander & exp)
 {
+  EvalResult result;
   auto & var = args.front();
-  Node * curr = n;
-  while ((curr = curr->parent()))
+  std::string used_path;
+  if (auto src = exp.findReferencedField(n, var, &used_path))
   {
-    auto src = curr->find(var);
-    if (src && src != n && src->type() == NodeType::Field)
-    {
-      exp.used.push_back(pathJoin({curr->fullpath(), var}));
-      // change kind only (not val)
-      n->setVal(n->val(), dynamic_cast<Field *>(src)->kind());
-      return curr->param<std::string>(var);
-    }
+    const auto & resolved = exp.resolve(src);
+    result.used.push_back(used_path);
+    result.kind = resolved.kind != Field::Kind::None ? resolved.kind : src->kind();
+    result.value = resolved.value;
+    return result;
   }
 
-  exp.errors.emplace_back("no variable '" + var + "' found for substitution expression", n);
-  return n->val();
+  exp.errors.push_back(exp.currentExpressionErrorMessage(
+      n, "no variable '" + var + "' found for substitution expression in '" + n->fullpath() + "'"));
+  result.value = n->val();
+  return result;
 }
-
-size_t parseBraceNode(const std::string & input, size_t start, BraceNode & n);
-size_t parseBraceBody(const std::string & input, size_t start, BraceNode & n);
 
 void
 BraceExpander::registerEvaler(const std::string & name, Evaler & ev)
@@ -91,18 +346,8 @@ BraceExpander::walk(const std::string & /*fullpath*/, const std::string & /*node
 
   try
   {
-    auto unquoted = f->val();
-    auto quote = quoteChar(f->val());
-    if (quote != "")
-      unquoted = unquoted.substr(1, unquoted.size() - 2);
-
-    std::string s;
-    s = expand(f, unquoted);
-    if (f->kind() == Field::Kind::String)
-      s = quote + s + quote;
-
-    if (errors.size() == 0)
-      f->setVal(s);
+    const auto & result = resolve(f);
+    used.insert(used.end(), result.used.begin(), result.used.end());
   }
   catch (Error & err)
   {
@@ -114,101 +359,265 @@ BraceExpander::walk(const std::string & /*fullpath*/, const std::string & /*node
 std::string
 BraceExpander::expand(Field * f, const std::string & input)
 {
-  std::string result = input;
-  size_t start = 0;
-  int count = 0;
-  while ((start = result.find("${", start)) != std::string::npos)
+  BraceTemplate root;
+  BraceParseError error;
+  try
   {
-    BraceNode root;
-    parseBraceNode(result, start, root);
-
-    auto replace_text = expand(f, root);
-    result.replace(root.offset(), root.len(), replace_text);
-    start = root.offset() + replace_text.size();
-    count++;
+    root = parseBraceTemplate(input, &error);
+  }
+  catch (const Error &)
+  {
+    throw syntaxError(f, error);
   }
 
-  // switch kind back to string if there are multiple top-level brace expressions or there is text
-  // outside of the single brace expression
-  if (count > 1 || (count == 1 && (input.rfind("}") - input.find("${") + 1 < input.size())))
-    // change kind only (not val)
-    f->setVal(f->val(), Field::Kind::String);
+  auto result = evaluate(f, root);
+  return result.value;
+}
+
+Field *
+BraceExpander::findReferencedField(Field * n, const std::string & path, std::string * used_path)
+{
+  Node * curr = n;
+  while ((curr = curr->parent()))
+  {
+    auto src = curr->find(path);
+    if (src && src != n && src->type() == NodeType::Field)
+    {
+      if (used_path)
+        *used_path = pathJoin({curr->fullpath(), path});
+      return dynamic_cast<Field *>(src);
+    }
+  }
+
+  return nullptr;
+}
+
+const EvalResult &
+BraceExpander::resolve(Field * n)
+{
+  auto & entry = _resolved[n];
+  if (entry.state == ResolveState::Resolved)
+    return entry.result;
+
+  if (entry.state == ResolveState::Resolving)
+  {
+    std::string chain;
+    for (const auto * field : _resolving_stack)
+    {
+      if (!chain.empty())
+        chain += " -> ";
+      chain += field->fullpath();
+    }
+    if (!chain.empty())
+      chain += " -> ";
+    chain += n->fullpath();
+    throw Error("cyclic brace-expression dependency detected: " + chain, n);
+  }
+
+  entry.state = ResolveState::Resolving;
+  _resolving_stack.push_back(n);
+
+  auto restore = [&]()
+  {
+    _resolving_stack.pop_back();
+    if (entry.state != ResolveState::Resolved)
+      entry.state = ResolveState::Unvisited;
+  };
+
+  try
+  {
+    auto unquoted = n->val();
+    const auto quote = quoteChar(n->val());
+    if (quote != "")
+      unquoted = unquoted.substr(1, unquoted.size() - 2);
+
+    entry.result.value = unquoted;
+    entry.result.kind = n->kind();
+
+    if (unquoted.find("${") != std::string::npos)
+    {
+      BraceTemplate root;
+      BraceParseError error;
+      const auto error_count = errors.size();
+      try
+      {
+        root = parseBraceTemplate(unquoted, &error);
+      }
+      catch (const Error &)
+      {
+        throw syntaxError(n, error);
+      }
+
+      entry.result = evaluate(n, root);
+      if (errors.size() != error_count)
+      {
+        // Preserve the original field text when brace expansion recorded an error.
+        entry.result.value = unquoted;
+        entry.result.kind = n->kind();
+      }
+      else if (!root.pureExpression() && (root.expressionCount() > 0 || root.hasLiteralText()))
+        entry.result.kind = Field::Kind::String;
+      else if (root.pureExpression() && entry.result.kind == Field::Kind::None)
+        entry.result.kind = n->kind();
+    }
+
+    std::string rendered = entry.result.value;
+    if (entry.result.kind == Field::Kind::String && quote != "")
+      rendered = quote + rendered + quote;
+
+    n->setVal(rendered, entry.result.kind);
+    entry.state = ResolveState::Resolved;
+    restore();
+    return entry.result;
+  }
+  catch (...)
+  {
+    restore();
+    throw;
+  }
+}
+
+EvalResult
+BraceExpander::evaluate(Field * n, const BraceTemplate & expr)
+{
+  EvalResult result;
+  for (const auto & part : expr.parts())
+    if (std::holds_alternative<std::string>(part))
+    {
+      result.value += std::get<std::string>(part);
+      result.kind = Field::Kind::String;
+    }
+    else
+    {
+      auto child = evaluate(n, *std::get<std::shared_ptr<BraceExpr>>(part));
+      result.value += child.value;
+      result.used.insert(result.used.end(), child.used.begin(), child.used.end());
+      result.kind = expr.pureExpression() ? child.kind : Field::Kind::String;
+    }
 
   return result;
 }
 
-std::string
-BraceExpander::expand(Field * n, BraceNode & expr)
+EvalResult
+BraceExpander::evaluate(Field * n, const BraceExpr & expr)
 {
-  if (!expr.val().empty())
-    return expr.val();
+  std::vector<std::string> expanded_args;
+  std::vector<std::vector<std::string>> child_used;
+  expanded_args.reserve(expr.args().size());
+  child_used.reserve(expr.args().size());
+  for (const auto & arg : expr.args())
+  {
+    auto child = evaluate(n, arg.value());
+    expanded_args.push_back(child.value);
+    child_used.push_back(std::move(child.used));
+  }
 
-  auto args = expr.list();
-  std::list<std::string> expanded_args;
-  for (auto it = args.begin(); it != args.end(); ++it)
-    expanded_args.push_back(expand(n, *it));
+  if (expanded_args.empty())
+    throw expressionError(n, expr, "empty brace expression in '" + n->fullpath() + "'");
 
-  // Just use replace expander if no args given
-  if (expanded_args.size() == 1)
-    return _replace.eval(n, expanded_args, *this);
+  EvalResult result;
+  const auto * previous_expr = _active_expr;
+  _active_expr = &expr;
 
-  auto cmd = expanded_args.front();
-  if (_evalers.count(cmd) == 0)
-    throw Error("invalid brace-expression command '" + cmd + "'");
-  expanded_args.pop_front();
-  return _evalers[cmd]->eval(n, expanded_args, *this);
+  // Just use replace expander if one arg given
+  try
+  {
+    if (expanded_args.size() == 1)
+      result = _replace.eval(n, expanded_args, *this);
+    else
+    {
+      auto cmd = expanded_args.front();
+      if (_evalers.count(cmd) == 0)
+        throw expressionError(
+            n, expr, "invalid brace-expression command '" + cmd + "' in '" + n->fullpath() + "'");
+      expanded_args.erase(expanded_args.begin());
+      child_used.erase(child_used.begin());
+      result = _evalers[cmd]->eval(n, expanded_args, *this);
+    }
+  }
+  catch (...)
+  {
+    _active_expr = previous_expr;
+    throw;
+  }
+  _active_expr = previous_expr;
+
+  for (const auto & used_paths : child_used)
+    result.used.insert(result.used.end(), used_paths.begin(), used_paths.end());
+
+  return result;
 }
 
-size_t
-skipSpace(const std::string & input, size_t start)
+Error
+BraceExpander::syntaxError(Field * n, const BraceParseError & error) const
 {
-  const std::string space = "\n\t \r";
-  while (start < input.size() && space.find(input[start]) != std::string::npos)
-    start++;
-  return start;
+  const auto message = "invalid brace-expression syntax in '" + n->fullpath() + "'" +
+                       (error.message.empty() ? "" : ": " + error.message);
+
+  if (!error.message.empty())
+    return Error(std::vector<ErrorMessage>{
+        fieldValueErrorMessage(n, error.line, error.column, "${", message)});
+
+  return Error(message, n);
 }
 
-size_t
-untilSpace(const std::string & input, size_t start)
+Error
+BraceExpander::expressionError(Field * n, const BraceExpr & expr, const std::string & message) const
 {
-  const std::string space = "\n\t \r}";
-  while (start < input.size() && space.find(input[start]) == std::string::npos)
-    start++;
-  return start;
+  return Error(std::vector<ErrorMessage>{expressionErrorMessage(n, expr, message)});
+}
+
+ErrorMessage
+BraceExpander::expressionErrorMessage(Field * n,
+                                      const BraceExpr & expr,
+                                      const std::string & message) const
+{
+  const auto & span_text = expr.text().empty() ? std::string("${") : expr.text();
+  return fieldValueErrorMessage(n, expr.line(), expr.column(), span_text, message);
+}
+
+ErrorMessage
+BraceExpander::currentExpressionErrorMessage(Field * n, const std::string & message) const
+{
+  if (_active_expr)
+    return expressionErrorMessage(n, *_active_expr, message);
+
+  return ErrorMessage(message, n);
+}
+
+Error
+BraceExpander::currentExpressionError(Field * n, const std::string & message) const
+{
+  return Error(std::vector<ErrorMessage>{currentExpressionErrorMessage(n, message)});
 }
 
 size_t
 parseBraceNode(const std::string & input, size_t start, BraceNode & n)
 {
   n.offset() = start;
-  start += 2; // eat opening "${"
-  start = parseBraceBody(input, start, n);
-  start = skipSpace(input, start);
-  if (input[start] != '}')
-    throw Error("missing closing '}' in brace expression");
-  start++; // eat closing "}"
-  n.len() = start - n.offset();
-  return start;
-}
+  n.len() = 0;
+  n.val().clear();
+  n.list().clear();
 
-size_t
-parseBraceBody(const std::string & input, size_t start, BraceNode & n)
-{
-  start = skipSpace(input, start);
-  while (start < input.size() && input[start] != '}')
+  if (input.find("${", start) != start)
+    throw Error("missing opening '${' in brace expression");
+
+  auto pos = start + 2;
+  while (pos < input.size())
   {
-    if (input.find("${", start) == start)
-      start = parseBraceNode(input, start, n.append());
-    else
+    if (input.find("${", pos) == pos)
+      pos = parseBraceNode(input, pos, n.append());
+    else if (input[pos] == '}')
     {
-      auto end = untilSpace(input, start);
-      auto & child = n.append();
-      child.val() = input.substr(start, end - start);
-      start = end;
+      ++pos;
+      n.len() = pos - n.offset();
+      return pos;
     }
-    start = skipSpace(input, start);
+    else
+      ++pos;
   }
-  return start;
+
+  throw Error("missing closing '}' in brace expression");
 }
 
 } // namespace hit


### PR DESCRIPTION
Makes brace expansion in HIT work properly by recursively expanding starting from the innermost braces, rather than expanding in order of brace type. This enables arbitrary nesting.